### PR TITLE
only publish for some scala versions

### DIFF
--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -522,7 +522,9 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
 
         val tar = WorkflowStep.Run(
           List(s"tar cf targets.tar ${sanitized.mkString(" ")} project/target"),
-          name = Some("Compress target directories"))
+          name = Some("Compress target directories"),
+          cond = cond
+        )
 
         val upload = WorkflowStep.Use(
           UseRef.Public(

--- a/src/main/scala/sbtghactions/VersionUtil.scala
+++ b/src/main/scala/sbtghactions/VersionUtil.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtghactions
+
+private[sbtghactions] object VersionUtil {
+  def inferPublishVersions(versions: Seq[String]): Seq[String] = {
+    val versionMappings = versions.map { version =>
+      (inferPublishVersion(version), version)
+    }
+    versionMappings.map(_._1).distinct.flatMap { mappedVersion =>
+      versionMappings.find(_._1 == mappedVersion).map(_._2)
+    }
+  }
+
+  private def inferPublishVersion(version: String): String = {
+    if (version.startsWith("2.")) {
+      val splits = version.split("""\.""")
+      if (splits.length >= 2) {
+        s"2.${splits(1)}"
+      } else {
+        version
+      }
+    } else if (version.startsWith("3.")) {
+      "3"
+    } else {
+      version
+    }
+  }
+}

--- a/src/test/scala/sbtghactions/VersionUtilSpec.scala
+++ b/src/test/scala/sbtghactions/VersionUtilSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtghactions
+
+import org.specs2.mutable.Specification
+
+class VersionUtilSpec extends Specification {
+  "VersionUtil.inferPublishVersions" should {
+    "only publish for 1 Scala 3 version" in {
+      val crossVersions = Seq("2.12.15", "2.13.6", "3.0.2", "3.1.0")
+      VersionUtil.inferPublishVersions(crossVersions) mustEqual crossVersions.filterNot(_ == "3.1.0")
+    }
+    "only publish for 1 Scala 2.13 version" in {
+      val crossVersions = Seq("2.12.15", "2.13.5", "2.13.6", "3.0.2")
+      VersionUtil.inferPublishVersions(crossVersions) mustEqual crossVersions.filterNot(_ == "2.13.6")
+    }
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/djspiewak/sbt-github-actions/issues/85

Aim is to only publish one build if matrix.scala has 2.13.5 and 2.13.6 (based on fact both would build jars suffixed with _2.13).

Likewise only publish one build if matrix.scala has 3.0.2 and 3.1.0 (based on fact both would build jars suffixed with _3).
