### PR TITLE
Temporarily remove Windows from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,11 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         scala: [2.12.15]
         java: [temurin@11, graal_20.3.1@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Ignore line ending differences in git
-        if: contains(runner.os, 'windows')
-        shell: bash
-        run: git config --global core.autocrlf false
-
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:
@@ -63,14 +58,11 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - shell: bash
-        run: sbt ++${{ matrix.scala }} test scripted
+      - run: sbt ++${{ matrix.scala }} test scripted
 
       - name: Compress target directories
-        shell: bash
         run: tar cf targets.tar target project/target
 
       - name: Upload target directories
@@ -90,10 +82,6 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Ignore line ending differences in git
-        if: contains(runner.os, 'windows')
-        run: git config --global core.autocrlf false
-
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ ThisBuild / endYear := Some(2021)
 
 ThisBuild / crossScalaVersions := Seq("2.12.15")
 
-ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-latest")
+// Add windows-latest when https://github.com/sbt/sbt/issues/7082 is resolved
+ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
 ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm("20.3.1", "11")
 


### PR DESCRIPTION
This PR temporarily removes Windows from the CI. After @eed3si9n did some quick preliminary investigation into what could be causing the CI to fail on Windows, it seems to be due to some weird interactions with Windows pipes. This PR temporarily removes Windows from CI.

Note that I have sbt-github-actions setup on my personal Windows machine, so if needed I can always run the tests manually on the machine before a release.

Resolves: #123 