### PR TITLE
Update JDK to version 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         scala: [2.12.15]
-        java: [temurin@11, graal_20.3.1@11]
+        java: [temurin@17, graal_22.3.0@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,19 +32,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
-      - name: Setup GraalVM (graal_20.3.1@11)
-        if: matrix.java == 'graal_20.3.1@11'
+      - name: Setup GraalVM (graal_22.3.0@17)
+        if: matrix.java == 'graal_22.3.0@17'
         uses: DeLaGuardo/setup-graalvm@5.0
         with:
-          graalvm: 20.3.1
-          java: java11
+          graalvm: 22.3.0
+          java: java17
 
       - name: Cache sbt
         uses: actions/cache@v3
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.17]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -88,19 +88,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
-      - name: Setup GraalVM (graal_20.3.1@11)
-        if: matrix.java == 'graal_20.3.1@11'
+      - name: Setup GraalVM (graal_22.3.0@17)
+        if: matrix.java == 'graal_22.3.0@17'
         uses: DeLaGuardo/setup-graalvm@5.0
         with:
-          graalvm: 20.3.1
-          java: java11
+          graalvm: 22.3.0
+          java: java17
 
       - name: Cache sbt
         uses: actions/cache@v3

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / crossScalaVersions := Seq("2.12.15")
 // Add windows-latest when https://github.com/sbt/sbt/issues/7082 is resolved
 ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
-ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm("20.3.1", "11")
+ThisBuild / githubWorkflowJavaVersions := List(JavaSpec.temurin("17"), JavaSpec.graalvm("22.3.0", "17"))
 
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")


### PR DESCRIPTION
Updates JDK from 11 to 17 and also updates the GraalVM to latest version (see https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.3.0)