### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         scala: [2.12.15]
-        java: [temurin@11, graal_20.3.1@11]
+        java: [temurin@8, graal_20.3.1@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Setup GraalVM (graal_20.3.1@11)
         if: matrix.java == 'graal_20.3.1@11'
@@ -79,8 +79,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17]
-        java: [temurin@11]
+        scala: [2.12.15]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -88,12 +88,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Setup GraalVM (graal_20.3.1@11)
         if: matrix.java == 'graal_20.3.1@11'

--- a/build.sbt
+++ b/build.sbt
@@ -16,14 +16,19 @@
 
 name := "sbt-github-actions"
 
+lazy val scala212 = "2.12.15"
 ThisBuild / organization := "com.github.sbt"
-ThisBuild / crossScalaVersions := Seq("2.12.15")
+ThisBuild / crossScalaVersions := Seq(scala212)
+ThisBuild / scalaVersion := scala212
 
 // Add windows-latest when https://github.com/sbt/sbt/issues/7082 is resolved
 ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
-ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm("20.3.1", "11")
-
+ThisBuild / githubWorkflowJavaVersions :=
+  Seq(
+    JavaSpec.temurin("8"),
+    JavaSpec.graalvm("20.3.1", "11"),
+  )
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches :=


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-github-actions/issues/132

Problem
-------
1. Currently JDK 11 is used, but JDK 8 should be used so the plugin users can use any JDK that Scala supports.
2. `ThisBuild/scalaVersion` is not set, so it picks up 2.12.17 for publishing.

Solution
--------
1. JDK 8
2. Set `ThisBuild/scalaVersion`