### PR TITLE
Port githubWorkflowBuildSbtStepPreamble from sbt-typelevel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' githubWorkflowCheck
 
-      - run: sbt ++${{ matrix.scala }} test scripted
+      - run: sbt '++${{ matrix.scala }}' test scripted
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target
@@ -124,9 +124,10 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - env:
+      - name: Publish project
+        env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt ++${{ matrix.scala }} ci-release
+        run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ ThisBuild / githubWorkflowPublishTargetBranches :=
   )
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(
-    List("ci-release"),
+    commands = List("ci-release"),
+    name = Some("Publish project"),
     env = Map(
       "PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}",
       "PGP_SECRET" -> "${{ secrets.PGP_SECRET }}",

--- a/src/main/scala/sbtghactions/GenerativeKeys.scala
+++ b/src/main/scala/sbtghactions/GenerativeKeys.scala
@@ -40,10 +40,12 @@ trait GenerativeKeys {
 
   lazy val githubWorkflowBuildPreamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after base setup but before compiling and testing (default: [])")
   lazy val githubWorkflowBuildPostamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after comping and testing but before the end of the build job (default: [])")
+  lazy val githubWorkflowBuildSbtStepPreamble =settingKey[Seq[String]](s"Commands automatically prepended to a WorkflowStep.Sbt (default: ['++$${{ matrix.scala }}'])")
   lazy val githubWorkflowBuild = settingKey[Seq[WorkflowStep]]("A sequence of workflow steps which compile and test the project (default: [Sbt(List(\"test\"))])")
 
   lazy val githubWorkflowPublishPreamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after base setup but before publishing (default: [])")
   lazy val githubWorkflowPublishPostamble = settingKey[Seq[WorkflowStep]]("A list of steps to insert after publication but before the end of the publish job (default: [])")
+  lazy val githubWorkflowPublishSbtStepPreamble =settingKey[Seq[String]]("Commands automatically prepended to a WorkflowStep.Sbt during publishing (default: [''])")
   lazy val githubWorkflowPublish = settingKey[Seq[WorkflowStep]]("A sequence workflow steps which publishes the project (default: [Sbt(List(\"+publish\"))])")
   lazy val githubWorkflowPublishTargetBranches = settingKey[Seq[RefPredicate]]("A set of branch predicates which will be applied to determine whether the current branch gets a publication stage; if empty, publish will be skipped entirely (default: [== main])")
   lazy val githubWorkflowPublishCond = settingKey[Option[String]]("A set of conditionals to apply to the publish job to further restrict its run (default: [])")

--- a/src/main/scala/sbtghactions/WorkflowJob.scala
+++ b/src/main/scala/sbtghactions/WorkflowJob.scala
@@ -20,6 +20,7 @@ final case class WorkflowJob(
     id: String,
     name: String,
     steps: List[WorkflowStep],
+    sbtStepPreamble: List[String] = List(),
     cond: Option[String] = None,
     permissions: Option[Permissions] = None,
     env: Map[String, String] = Map(),

--- a/src/main/scala/sbtghactions/WorkflowStep.scala
+++ b/src/main/scala/sbtghactions/WorkflowStep.scala
@@ -25,6 +25,8 @@ sealed trait WorkflowStep extends Product with Serializable {
 
 object WorkflowStep {
 
+  val DefaultSbtStepPreamble: List[String] = List(s"++$${{ matrix.scala }}")
+
   val CheckoutFull: WorkflowStep = Use(
     UseRef.Public("actions", "checkout", "v3"),
     name = Some("Checkout current branch (full)"),

--- a/src/sbt-test/sbtghactions/check-and-regenerate/build.sbt
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/build.sbt
@@ -19,4 +19,12 @@ ThisBuild / githubWorkflowBuildMatrixExclusions +=
   MatrixExclude(Map("scala" -> "2.12.15", "test" -> "is"))
 
 ThisBuild / githubWorkflowBuild += WorkflowStep.Run(List("echo yo"))
-ThisBuild / githubWorkflowPublish += WorkflowStep.Run(List("echo sup"))
+
+ThisBuild / githubWorkflowPublish :=
+  Seq(
+    WorkflowStep.Sbt(
+      commands = List("ci-release"),
+      name = Some("Publish project"),
+    ),
+    WorkflowStep.Run(List("echo sup")),
+  )

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -66,10 +66,10 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt '++${{ matrix.scala }}' test
 
       - run: echo yo
 
@@ -145,6 +145,6 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt ++${{ matrix.scala }} +publish
+        run: sbt ci-release
 
       - run: echo sup

--- a/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt '++${{ matrix.scala }}' test
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target
@@ -121,4 +121,4 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt ++${{ matrix.scala }} +publish
+        run: sbt +publish

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' githubWorkflowCheck
 
-      - run: sbt ++${{ matrix.scala }} withTarget/compile
+      - run: sbt '++${{ matrix.scala }}' withTarget/compile
 
       - name: Compress target directories
         run: tar cf targets.tar target withTarget/target project/target
@@ -110,4 +110,4 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt ++${{ matrix.scala }} +publish
+        run: sbt +publish

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
@@ -127,4 +127,4 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt --client '++${{ matrix.scala }}; +publish'
+        run: sbt --client '+publish'

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
@@ -52,10 +52,10 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Build project
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt '++${{ matrix.scala }}' test
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target
@@ -112,4 +112,4 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt ++${{ matrix.scala }} +publish
+        run: sbt +publish

--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -352,7 +352,8 @@ class GenerativePluginSpec extends Specification {
           List("echo hi"),
           name = Some("nomenclature")),
         "",
-        true) mustEqual "- name: nomenclature\n  shell: bash\n  run: echo hi"
+        Nil,
+        declareShell = true) mustEqual "- name: nomenclature\n  shell: bash\n  run: echo hi"
     }
 
     "omit shell declaration on Use step" in {
@@ -363,27 +364,35 @@ class GenerativePluginSpec extends Specification {
             "slug",
             "v0")),
         "",
-        true) mustEqual "- uses: repo/slug@v0"
+        Nil,
+        declareShell = true) mustEqual "- uses: repo/slug@v0"
     }
 
     "preserve wonky version in Use" in {
-      compileStep(Use(UseRef.Public("hello", "world", "v4.0.0")), "", true) mustEqual "- uses: hello/world@v4.0.0"
+      compileStep(Use(UseRef.Public("hello", "world", "v4.0.0")), "", Nil, declareShell = true) mustEqual "- uses: hello/world@v4.0.0"
     }
 
     "drop Use version prefix on anything that doesn't start with a number" in {
-      compileStep(Use(UseRef.Public("hello", "world", "main")), "", true) mustEqual "- uses: hello/world@main"
+      compileStep(Use(UseRef.Public("hello", "world", "main")), "", Nil, declareShell = true) mustEqual "- uses: hello/world@main"
     }
 
     "compile sbt using the command provided" in {
       compileStep(
         Sbt(List("show scalaVersion", "compile", "test")),
-        "$SBT") mustEqual s"- run: $$SBT ++$${{ matrix.scala }} 'show scalaVersion' compile test"
+        "$SBT") mustEqual s"- run: $$SBT '++$${{ matrix.scala }}' 'show scalaVersion' compile test"
+    }
+
+    "compile sbt without switch command" in {
+      compileStep(
+        Sbt(List("ci-release")),
+        "$SBT",
+        sbtStepPreamble = Nil) mustEqual s"- run: $$SBT ci-release"
     }
 
     "compile sbt with parameters" in {
       compileStep(
         Sbt(List("compile", "test"), params = Map("abc" -> "def", "cafe" -> "@42")),
-        "$SBT") mustEqual s"""- run: $$SBT ++$${{ matrix.scala }} compile test
+        "$SBT") mustEqual s"""- run: $$SBT '++$${{ matrix.scala }}' compile test
                          |  with:
                          |    abc: def
                          |    cafe: '@42'""".stripMargin
@@ -553,6 +562,7 @@ class GenerativePluginSpec extends Specification {
           "Moooo",
           List(
             WorkflowStep.Sbt(List("+compile"))),
+          sbtStepPreamble = WorkflowStep.DefaultSbtStepPreamble,
           env = Map("not" -> "now"),
           cond = Some("boy != girl"),
           needs = List("unmet")),
@@ -571,7 +581,7 @@ class GenerativePluginSpec extends Specification {
   env:
     not: now
   steps:
-    - run: csbt ++$${{ matrix.scala }} +compile"""
+    - run: csbt '++$${{ matrix.scala }}' +compile"""
     }
 
     "compile a job with an environment" in {
@@ -594,7 +604,7 @@ class GenerativePluginSpec extends Specification {
   runs-on: $${{ matrix.os }}
   environment: release
   steps:
-    - run: csbt ++$${{ matrix.scala }} ci-release"""
+    - run: csbt ci-release"""
     }
 
     "compile a job with specific permissions" in {
@@ -622,7 +632,7 @@ class GenerativePluginSpec extends Specification {
   permissions:
     id-token: write
   steps:
-    - run: csbt ++$${{ matrix.scala }} ci-release"""
+    - run: csbt ci-release"""
     }
 
     "compile a job with read-all permissions" in {
@@ -646,7 +656,7 @@ class GenerativePluginSpec extends Specification {
   runs-on: $${{ matrix.os }}
   permissions: read-all
   steps:
-    - run: csbt ++$${{ matrix.scala }} ci-release"""
+    - run: csbt ci-release"""
     }
 
     "compile a job with an environment containing a url" in {
@@ -671,7 +681,7 @@ class GenerativePluginSpec extends Specification {
     name: release
     url: 'https://github.com'
   steps:
-    - run: csbt ++$${{ matrix.scala }} ci-release"""
+    - run: csbt ci-release"""
     }
 
     "compile a job with additional matrix components" in {


### PR DESCRIPTION
Ref https://github.com/typelevel/sbt-typelevel/pull/64

Problem
-------
We don't want `++matrix.scala` to happen in the case of publishing.

Solution
--------
This ports `githubWorkflowBuildSbtStepPreamble` mechanism from sbt-typelevel with additional support for `githubWorkflowPublishSbtStepPreamble`.