### PR TITLE
Switch to using graalvm/setup-graalvm@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,25 +38,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+          cache: sbt
 
       - name: Setup GraalVM (graal_20.3.1@11)
         if: matrix.java == 'graal_20.3.1@11'
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: 20.3.1
-          java: java11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          version: 20.3.1
+          java-version: 11
+          components: native-image
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
@@ -94,25 +85,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+          cache: sbt
 
       - name: Setup GraalVM (graal_20.3.1@11)
         if: matrix.java == 'graal_20.3.1@11'
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: 20.3.1
-          java: java11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          version: 20.3.1
+          java-version: 11
+          components: native-image
+          cache: sbt
 
       - name: Download target directories (2.12.15)
         uses: actions/download-artifact@v3

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -646,32 +646,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       }
     },
 
-    githubWorkflowGeneratedCacheSteps := {
-      val hashes = githubWorkflowDependencyPatterns.value map { glob =>
-        s"$${{ hashFiles('$glob') }}"
-      }
-
-      Seq(
-        WorkflowStep.Use(
-          UseRef.Public(
-            "actions",
-            "cache",
-            "v3"),
-          name = Some("Cache sbt"),
-          params = Map(
-            "path" -> Seq(
-              "~/.sbt",
-              "~/.ivy2/cache",
-              "~/.coursier/cache/v1",
-              "~/.cache/coursier/v1",
-              "~/AppData/Local/Coursier/Cache/v1",
-              "~/Library/Caches/Coursier/v1"
-            ).mkString("\n"),
-            "key" -> s"$${{ runner.os }}-sbt-cache-v3-${hashes.mkString("-")}"
-          )
-        )
-      )
-    },
+    githubWorkflowGeneratedCacheSteps := Nil,
 
     githubWorkflowJobSetup := {
       val autoCrlfOpt = if (githubWorkflowOSes.value.exists(_.contains("windows"))) {

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -45,25 +45,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+          cache: sbt
 
       - name: Setup GraalVM (graal_21.1.0@8)
         if: matrix.java == 'graal_21.1.0@8'
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: 21.1.0
-          java: java8
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          version: 21.1.0
+          java-version: 8
+          components: native-image
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
@@ -104,25 +95,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+          cache: sbt
 
       - name: Setup GraalVM (graal_21.1.0@8)
         if: matrix.java == 'graal_21.1.0@8'
-        uses: DeLaGuardo/setup-graalvm@5.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: 21.1.0
-          java: java8
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          version: 21.1.0
+          java-version: 8
+          components: native-image
+          cache: sbt
 
       - name: Download target directories (2.13.6)
         uses: actions/download-artifact@v3

--- a/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
@@ -37,18 +37,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
@@ -87,18 +76,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Download target directories (2.13.6)
         uses: actions/download-artifact@v3

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -37,18 +37,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
@@ -86,18 +75,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Download target directories (2.13.6)
         uses: actions/download-artifact@v3

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
@@ -37,18 +37,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
@@ -103,18 +92,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Download target directories (2.12.14)
         uses: actions/download-artifact@v3

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
@@ -38,18 +38,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
@@ -88,18 +77,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v3-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Download target directories (2.13.6)
         uses: actions/download-artifact@v3

--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -537,13 +537,16 @@ class GenerativePluginSpec extends Specification {
       with:
         distribution: temurin
         java-version: 11
+        cache: sbt
 
     - name: Setup GraalVM (graal_20.0.0@8)
       if: matrix.java == 'graal_20.0.0@8'
-      uses: DeLaGuardo/setup-graalvm@5.0
+      uses: graalvm/setup-graalvm@v1
       with:
-        graalvm: 20.0.0
-        java: java8"""
+        version: 20.0.0
+        java-version: 8
+        components: native-image
+        cache: sbt"""
     }
 
     "compile a job with environment variables, conditional, and needs with an sbt step" in {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-github-actions/issues/104

This switches to using `graalvm/setup-graalvm@v1` for GraalVM. Supposedly this offers `cache: sbt` so we can remove our custom caching.