### PR TITLE
Support newer Graalvm JDK 17 distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         scala: [2.12.18]
-        java: [temurin@8, graal_22.3.0@17]
+        java: [temurin@8, graal_graalvm@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -40,12 +40,12 @@ jobs:
           java-version: 8
           cache: sbt
 
-      - name: Setup GraalVM (graal_22.3.0@17)
-        if: matrix.java == 'graal_22.3.0@17'
+      - name: Setup GraalVM (graal_graalvm@17)
+        if: matrix.java == 'graal_graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: 22.3.0
           java-version: 17
+          distribution: graalvm
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt
@@ -88,12 +88,12 @@ jobs:
           java-version: 8
           cache: sbt
 
-      - name: Setup GraalVM (graal_22.3.0@17)
-        if: matrix.java == 'graal_22.3.0@17'
+      - name: Setup GraalVM (graal_graalvm@17)
+        if: matrix.java == 'graal_graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: 22.3.0
           java-version: 17
+          distribution: graalvm
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalaVersion := scala212
 // Add windows-latest when https://github.com/sbt/sbt/issues/7082 is resolved
 ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest")
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted")))
-ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm("22.3.0", "17")
+ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "17")
 
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches :=

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -70,6 +70,9 @@ object GenerativePlugin extends AutoPlugin {
 
     type PermissionValue = sbtghactions.PermissionValue
     val PermissionValue = sbtghactions.PermissionValue
+
+    type Graalvm = sbtghactions.Graalvm
+    val Graalvm = sbtghactions.Graalvm
   }
 
   import autoImport._

--- a/src/main/scala/sbtghactions/WorkflowStep.scala
+++ b/src/main/scala/sbtghactions/WorkflowStep.scala
@@ -41,7 +41,7 @@ object WorkflowStep {
 
   def SetupJava(versions: List[JavaSpec]): List[WorkflowStep] =
     versions map {
-      case jv @ JavaSpec(JavaSpec.Distribution.GraalVM(graalVersion), version) =>
+      case jv @ JavaSpec(JavaSpec.Distribution.GraalVM(Graalvm.Version(graalVersion)), version) =>
         WorkflowStep.Use(
           UseRef.Public("graalvm", "setup-graalvm", "v1"),
           name = Some(s"Setup GraalVM (${jv.render})"),
@@ -52,7 +52,17 @@ object WorkflowStep {
             "components" -> "native-image",
             "github-token" -> s"$${{ secrets.GITHUB_TOKEN }}",
             "cache" -> "sbt"))
-
+      case jv @ JavaSpec(JavaSpec.Distribution.GraalVM(Graalvm.Distribution(distribution)), version) =>
+        WorkflowStep.Use(
+          UseRef.Public("graalvm", "setup-graalvm", "v1"),
+          name = Some(s"Setup GraalVM (${jv.render})"),
+          cond = Some(s"matrix.java == '${jv.render}'"),
+          params = ListMap(
+            "java-version" -> s"$version",
+            "distribution" -> distribution,
+            "components" -> "native-image",
+            "github-token" -> s"$${{ secrets.GITHUB_TOKEN }}",
+            "cache" -> "sbt"))
       case jv @ JavaSpec(dist, version) =>
         WorkflowStep.Use(
           UseRef.Public("actions", "setup-java", "v3"),

--- a/src/sbt-test/sbtghactions/check-and-regenerate/build.sbt
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 ThisBuild / githubWorkflowTargetTags += "v*"
 
-ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm("22.3.0", "17")
+ThisBuild / githubWorkflowJavaVersions += JavaSpec.graalvm(Graalvm.Version("22.3.0"), "17")
 ThisBuild / githubWorkflowPublishTargetBranches += RefPredicate.Equals(Ref.Tag("test"))
 
 ThisBuild / githubWorkflowBuildMatrixAdditions += "test" -> List("this", "is")


### PR DESCRIPTION
This PR adds support for the new updates to the  `setup-graalvm` github action which allows you to specify different graalvm distributions (i.e. graalvm, graalvm-community and mandrel), see https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later for more details.

Rather than just using a raw string, this PR introduces a new trait called `Graalvm` which allows you to specify which format of the github action you want to use. It was done this way because the `setup-graalvm` github action doesn't allow using graalvm distributions for JDK versions older than 17. Basic validation for throwing exceptions was also added to verify this (i.e. you cannot use `Graalvm.Distribution` if the JDK is older than 17).

The final rendering of the github action is the same if you `Graalvm.Version` (i.e. current `JavaSpec.graalvm("22.3.0", "17")` renders the same as this PR's `JavaSpec.graalvm(Graalvm.Version("22.3.0"), "17")` but not `JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "17")`. The old version of `def graalvm(graal: String, version: String): JavaSpec` was retained to not break current sbt project builds but its been marked as deprecated.

Furthermore this PR updates `build.sbt` to use the new `Graalvm.Distribution` so that we are testing our own dog food (i.e. just to make sure that this new `setup-graalvm` github action feature works).