### PR TITLE
Add sbt/setup-sbt to install sbt + default to zulu@8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         scala: [2.12.18]
-        java: [temurin@8, graal_graalvm@17, corretto@17]
+        java: [zulu@8, graal_graalvm@17, corretto@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -45,11 +45,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
 
@@ -70,6 +70,9 @@ jobs:
           distribution: corretto
           java-version: 17
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         shell: bash
@@ -96,7 +99,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.18]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -116,11 +119,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
 
@@ -141,6 +144,9 @@ jobs:
           distribution: corretto
           java-version: 17
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v4

--- a/src/main/scala/sbtghactions/GenerativeKeys.scala
+++ b/src/main/scala/sbtghactions/GenerativeKeys.scala
@@ -55,7 +55,7 @@ trait GenerativeKeys {
   lazy val githubWorkflowPublishCond = settingKey[Option[String]]("A set of conditionals to apply to the publish job to further restrict its run (default: [])")
   lazy val githubWorkflowPublishTimeout = settingKey[Option[FiniteDuration]]("The maximum duration to let the publish job run before GitHub automatically cancels it. (default: None)")
 
-  lazy val githubWorkflowJavaVersions = settingKey[Seq[JavaSpec]]("A list of Java versions to be used for the build job. The publish job will use the *first* of these versions. (default: [temurin@8])")
+  lazy val githubWorkflowJavaVersions = settingKey[Seq[JavaSpec]]("A list of Java versions to be used for the build job. The publish job will use the *first* of these versions. (default: [zulu@8])")
   lazy val githubWorkflowScalaVersions = settingKey[Seq[String]]("A list of Scala versions on which to build the project (default: crossScalaVersions.value)")
   lazy val githubWorkflowOSes = settingKey[Seq[String]]("A list of OS names (default: [ubuntu-latest])")
 

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -578,7 +578,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     githubWorkflowPublishCond := None,
     githubWorkflowPublishTimeout := None,
 
-    githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
+    githubWorkflowJavaVersions := Seq(JavaSpec.zulu("8")),
     githubWorkflowScalaVersions := crossScalaVersions.value,
     githubWorkflowOSes := Seq("ubuntu-latest"),
     githubWorkflowDependencyPatterns := Seq("**/*.sbt", "project/build.properties"),
@@ -710,6 +710,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       autoCrlfOpt :::
         List(WorkflowStep.CheckoutFull) :::
         WorkflowStep.SetupJava(githubWorkflowJavaVersions.value.toList) :::
+        List(WorkflowStep.SetupSbt()) :::
         githubWorkflowGeneratedCacheSteps.value.toList
     },
 

--- a/src/main/scala/sbtghactions/JavaSpec.scala
+++ b/src/main/scala/sbtghactions/JavaSpec.scala
@@ -54,6 +54,8 @@ object JavaSpec {
 
   def temurin(version: String): JavaSpec = JavaSpec(Distribution.Temurin, version)
 
+  def zulu(version: String): JavaSpec = JavaSpec(Distribution.Zulu, version)
+
   def corretto(version: String): JavaSpec = JavaSpec(Distribution.Corretto, version)
 
   private[sbtghactions] object JavaVersionExtractor {

--- a/src/main/scala/sbtghactions/WorkflowJob.scala
+++ b/src/main/scala/sbtghactions/WorkflowJob.scala
@@ -28,7 +28,7 @@ final case class WorkflowJob(
     env: Map[String, String] = Map(),
     oses: List[String] = List("ubuntu-latest"),
     scalas: List[String] = List("2.13.10"),
-    javas: List[JavaSpec] = List(JavaSpec.temurin("8")),
+    javas: List[JavaSpec] = List(JavaSpec.zulu("8")),
     needs: List[String] = List(),
     matrixFailFast: Option[Boolean] = None,
     matrixAdds: Map[String, List[String]] = Map(),

--- a/src/main/scala/sbtghactions/WorkflowStep.scala
+++ b/src/main/scala/sbtghactions/WorkflowStep.scala
@@ -74,6 +74,16 @@ object WorkflowStep {
             "cache" -> "sbt"))
     }
 
+  def SetupSbt(runnerVersion: Option[String] = None): WorkflowStep =
+    Use(
+      ref = UseRef.Public("sbt", "setup-sbt", "v1"),
+      params = runnerVersion match {
+        case Some(v) => Map("sbt-runner-version" -> v)
+        case None    => Map()
+      },
+      name = Some("Setup sbt"),
+    )
+
   val Tmate: WorkflowStep = Use(UseRef.Public("mxschmitt", "action-tmate", "v2"), name = Some("Setup tmate session"))
 
   def ComputeVar(name: String, cmd: String): WorkflowStep =

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10, 2.12.17]
-        java: [temurin@8, graal_22.3.0@17]
+        java: [zulu@8, graal_22.3.0@17]
         test: [this, is]
         include:
           - test: this
@@ -41,11 +41,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
 
@@ -58,6 +58,9 @@ jobs:
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -84,7 +87,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -94,11 +97,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
 
@@ -111,6 +114,9 @@ jobs:
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [windows-latest]
         scala: [2.13.10, 2.12.17]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -44,13 +44,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         shell: bash
@@ -78,7 +81,7 @@ jobs:
       matrix:
         os: [windows-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -99,13 +102,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10, 2.12.17]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,13 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -62,7 +65,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -70,13 +73,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,13 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -61,7 +64,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -69,13 +72,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.18]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -31,13 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt --client '++ ${{ matrix.scala }}; githubWorkflowCheck'
@@ -78,7 +81,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.18]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -86,13 +89,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,13 +32,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -63,7 +66,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [temurin@8]
+        java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -71,13 +74,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
+      - name: Setup Java (zulu@8)
+        if: matrix.java == 'zulu@8'
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
           cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -109,7 +109,7 @@ class GenerativePluginSpec extends Specification {
         |      matrix:
         |        os: [ubuntu-latest]
         |        scala: [2.13.10]
-        |        java: [temurin@8]
+        |        java: [zulu@8]
         |    runs-on: $${{ matrix.os }}
         |    steps:
         |      - run: echo Hello World
@@ -151,7 +151,7 @@ class GenerativePluginSpec extends Specification {
         |      matrix:
         |        os: [ubuntu-latest]
         |        scala: [2.13.10]
-        |        java: [temurin@8]
+        |        java: [zulu@8]
         |    runs-on: $${{ matrix.os }}
         |    steps:
         |      - run: echo yikes
@@ -162,7 +162,7 @@ class GenerativePluginSpec extends Specification {
         |      matrix:
         |        os: [ubuntu-latest]
         |        scala: [2.13.10]
-        |        java: [temurin@8]
+        |        java: [zulu@8]
         |    runs-on: $${{ matrix.os }}
         |    steps:
         |      - run: whoami
@@ -206,7 +206,7 @@ class GenerativePluginSpec extends Specification {
         |      matrix:
         |        os: [ubuntu-latest]
         |        scala: [2.13.10]
-        |        java: [temurin@8]
+        |        java: [zulu@8]
         |    runs-on: $${{ matrix.os }}
         |    container: 'not:real-thing'
         |    steps:
@@ -248,7 +248,7 @@ class GenerativePluginSpec extends Specification {
         |      matrix:
         |        os: [ubuntu-latest]
         |        scala: [2.13.10]
-        |        java: [temurin@8]
+        |        java: [zulu@8]
         |    runs-on: $${{ matrix.os }}
         |    container:
         |      image: 'also:not-real'
@@ -510,7 +510,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   steps:
     - run: echo hello
@@ -535,7 +535,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest, windows-latest, macos-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   steps:
     - shell: bash
@@ -643,7 +643,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   env:
     not: now
@@ -667,7 +667,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   environment: release
   steps:
@@ -694,7 +694,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   permissions:
     id-token: write
@@ -719,7 +719,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   permissions: read-all
   steps:
@@ -742,7 +742,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   environment:
     name: release
@@ -770,7 +770,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
       test: [1, 2]
   runs-on: $${{ matrix.os }}
   steps:
@@ -794,7 +794,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: [ "${{ matrix.os }}", runner-label, runner-group ]
   steps:
     - run: echo hello"""
@@ -816,7 +816,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   timeout-minutes: 60
 
@@ -863,7 +863,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
       include:
         - scala: 2.13.10
           foo: bar
@@ -918,7 +918,7 @@ class GenerativePluginSpec extends Specification {
     matrix:
       os: [ubuntu-latest]
       scala: [2.13.10]
-      java: [temurin@8]
+      java: [zulu@8]
       exclude:
         - scala: 2.13.10
   runs-on: $${{ matrix.os }}
@@ -961,7 +961,7 @@ class GenerativePluginSpec extends Specification {
             WorkflowStep.Run(List("echo ${{ matrix.scala }}"))),
           matrixExcs = List(
             MatrixExclude(
-              Map("java" -> JavaSpec.temurin("8").render)))),
+              Map("java" -> JavaSpec.zulu("8").render)))),
         "") must not(throwA[RuntimeException])
     }
 
@@ -994,7 +994,7 @@ class GenerativePluginSpec extends Specification {
         - the
         - bounds
         - checking
-      java: [temurin@8]
+      java: [zulu@8]
   runs-on: $${{ matrix.os }}
   steps:
     - run: echo hello


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-github-actions/issues/185

## Problem
1. Recent runner images no longer have sbt runner scripts installed.
2. setup-java doesn't have temurin 8 for ARM macOS

## Solution
1. This adds sbt/setup-sbt step to install `sbt` runner script.
2. This also defaults to Zulu 8.