### PR TITLE
Rename sbt/setup-sbt or sbt/setup-sbt-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         shell: bash
@@ -146,7 +146,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v4

--- a/src/main/scala/sbtghactions/WorkflowStep.scala
+++ b/src/main/scala/sbtghactions/WorkflowStep.scala
@@ -76,7 +76,7 @@ object WorkflowStep {
 
   def SetupSbt(runnerVersion: Option[String] = None): WorkflowStep =
     Use(
-      ref = UseRef.Public("sbt", "setup-sbt", "v1"),
+      ref = UseRef.Public("sbt", "setup-sbt-runner", "v1"),
       params = runnerVersion match {
         case Some(v) => Map("sbt-runner-version" -> v)
         case None    => Map()

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -60,7 +60,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -116,7 +116,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         shell: bash
@@ -111,7 +111,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -82,7 +82,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -81,7 +81,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         run: sbt --client '++ ${{ matrix.scala }}; githubWorkflowCheck'
@@ -98,7 +98,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v4

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
@@ -41,7 +41,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -83,7 +83,7 @@ jobs:
           cache: sbt
 
       - name: Setup sbt
-        uses: sbt/setup-sbt@v1
+        uses: sbt/setup-sbt-runner@v1
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**Problem**
See https://github.com/sbt/setup-sbt/issues/2

Apparently sbt/setup-sbt causes a permission issue on non-sbt repo:

> sbt/setup-sbt@v1 is not allowed to be used in pjfanning/micrometer-pekko. Actions in this workflow must be: within a repository owned by pjfanning, created by GitHub, or verified in the GitHub Marketplace.

**Solution**
I've now copied the action to sbt/setup-sbt-runner. This is registered to the Marketplace - https://github.com/marketplace/actions/setup-sbt-runner

/cc @pjfanning