### PR TITLE
Added permissions to clean.yml

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -800,6 +800,9 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
          |
          |on: push
          |
+         |permissions:
+         |  actions: write
+         |
          |jobs:
          |  delete-artifacts:
          |    name: Delete Artifacts

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-clean.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/clean.yml
+++ b/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/clean.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/clean.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-clean.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-clean.yml
@@ -9,6 +9,9 @@ name: Clean
 
 on: push
 
+permissions:
+  actions: write
+
 jobs:
   delete-artifacts:
     name: Delete Artifacts


### PR DESCRIPTION
Currently clean.yml does not specify permissions, which means it runs with the default (often fairly powerful) set of permissions.

It might be better from a security perspective to grant it only the minimally necessary permissions.