### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -18,7 +18,7 @@ package sbtghactions
 
 import org.specs2.mutable.Specification
 
-import java.net.URL
+import java.net.URI
 import scala.concurrent.duration.DurationInt
 
 class GenerativePluginSpec extends Specification {
@@ -733,7 +733,7 @@ class GenerativePluginSpec extends Specification {
           "Publish Release",
           List(
             WorkflowStep.Sbt(List("ci-release"))),
-          environment = Some(JobEnvironment("release", Some(new URL("https://github.com"))))),
+          environment = Some(JobEnvironment("release", Some(new URI("https://github.com").toURL)))),
         "csbt")
 
       results mustEqual s"""publish:


### PR DESCRIPTION
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)
- https://bugs.openjdk.org/browse/JDK-8295949