### PR TITLE
fix: Always use semicolon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,15 @@ jobs:
 
       - name: Check that workflows are up to date
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - if: matrix.java != 'zulu@8'
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' '+ test' '+ scripted'
+        run: sbt '++ ${{ matrix.scala }}; + test; + scripted'
 
       - if: matrix.java == 'zulu@8'
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' test scripted
+        run: sbt '++ ${{ matrix.scala }}; test; scripted'
 
       - name: Clean up Ivy Local repo
         shell: bash

--- a/src/main/scala/sbtghactions/GenerativePlugin.scala
+++ b/src/main/scala/sbtghactions/GenerativePlugin.scala
@@ -281,18 +281,12 @@ ${indent(rendered.mkString("\n"), 1)}"""
       case sbtStep: Sbt =>
         import sbtStep.commands
 
-        val sbtClientMode = sbt.matches("""sbt.* --client($| .*)""")
-        val safeCommands = if (sbtClientMode)
-          s"'${(sbtStepPreamble ::: commands).mkString("; ")}'"
-        else (sbtStepPreamble ::: commands).map { c =>
-          if (c.indexOf(' ') >= 0)
-            s"'$c'"
-          else
-            c
-        }.mkString(" ")
-
+        val multi = (sbtStepPreamble ::: commands) match {
+          case x :: Nil => x
+          case xs       => s"'${xs.mkString("; ")}'"
+        }
         renderRunBody(
-          commands = List(s"$sbt $safeCommands"),
+          commands = List(s"$sbt $multi"),
           params = sbtStep.params,
           renderedShell = renderedShell
         )

--- a/src/sbt-test/sbtghactions/allow-hashes/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/allow-hashes/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}; test'
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target

--- a/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/check-and-regenerate/expected-ci.yml
@@ -63,10 +63,10 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}; test'
 
       - run: echo yo
 

--- a/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/githubworkflowoses-clean-publish/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
 
       - name: Check that workflows are up to date
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
         shell: bash
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}; test'
 
       - name: Compress target directories
         shell: bash

--- a/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/no-clean/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}; test'
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target

--- a/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/non-existent-target/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
-      - run: sbt '++ ${{ matrix.scala }}' withTarget/compile
+      - run: sbt '++ ${{ matrix.scala }}; withTarget/compile'
 
       - name: Compress target directories
         run: tar cf targets.tar target withTarget/target project/target

--- a/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
+++ b/src/sbt-test/sbtghactions/sbt-native-thin-client/.github/workflows/ci.yml
@@ -111,4 +111,4 @@ jobs:
           rm targets.tar
 
       - name: Publish project
-        run: sbt --client '+publish'
+        run: sbt --client +publish

--- a/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
+++ b/src/sbt-test/sbtghactions/suppressed-scala-version/expected-ci.yml
@@ -44,10 +44,10 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: sbt '++ ${{ matrix.scala }}; test'
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target

--- a/src/test/scala/sbtghactions/GenerativePluginSpec.scala
+++ b/src/test/scala/sbtghactions/GenerativePluginSpec.scala
@@ -431,7 +431,7 @@ class GenerativePluginSpec extends Specification {
     "compile sbt using the command provided" in {
       compileStep(
         Sbt(List("show scalaVersion", "compile", "test")),
-        "$SBT") mustEqual s"- run: $$SBT '++ $${{ matrix.scala }}' 'show scalaVersion' compile test"
+        "$SBT") mustEqual s"- run: $$SBT '++ $${{ matrix.scala }}; show scalaVersion; compile; test'"
     }
 
     "compile sbt without switch command" in {
@@ -444,7 +444,7 @@ class GenerativePluginSpec extends Specification {
     "compile sbt with parameters" in {
       compileStep(
         Sbt(List("compile", "test"), params = Map("abc" -> "def", "cafe" -> "@42")),
-        "$SBT") mustEqual s"""- run: $$SBT '++ $${{ matrix.scala }}' compile test
+        "$SBT") mustEqual s"""- run: $$SBT '++ $${{ matrix.scala }}; compile; test'
                          |  with:
                          |    abc: def
                          |    cafe: '@42'""".stripMargin
@@ -699,7 +699,7 @@ class GenerativePluginSpec extends Specification {
   env:
     not: now
   steps:
-    - run: csbt '++ $${{ matrix.scala }}' +compile"""
+    - run: csbt '++ $${{ matrix.scala }}; +compile'"""
     }
 
     "compile a job with an environment" in {


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-github-actions/issues/225

## Problem
With sbt 2.x, the runner defaults to using sbtn,
which interprets sbt foo bar as a single command.

## Solution
This injects semicolon as sbt "foo; bar"